### PR TITLE
fix: fib seq test to start on 0, p26

### DIFF
--- a/src/rich4clojure/easy/problem_026.clj
+++ b/src/rich4clojure/easy/problem_026.clj
@@ -16,9 +16,9 @@
   )
 
 (tests
-  (__ 3) := '(1 1 2)
-  (__ 6) := '(1 1 2 3 5 8)
-  (__ 8) := '(1 1 2 3 5 8 13 21))
+  (__ 4) := '(0 1 1 2)
+  (__ 7) := '(0 1 1 2 3 5 8)
+  (__ 9) := '(0 1 1 2 3 5 8 13 21))
 
 ;; Share your solution, and/or check how others did it:
 ;; https://gist.github.com/87153a8e55b56058703e5bca6f8ba62a


### PR DESCRIPTION
## What does it do?

In problem 026 the student is asked to return "the first X Fibonacci numbers".
It happens that the Fibonacci sequence starts with 0, i.e.: (0 1 1 2 ...).

This is a bit of a nit detail, but I feel it's important to be the most correct possible.
So I've decided to propose this fix to the tests in order to include 0 at the beginning of the sequence.

## Concerns / Breaking Changes?
None that I know of.

## How to test?

1. Copy-paste this code to the file `problem_026.clj`

```clojure
(def lazy-cat-fib
  (lazy-cat [0 1]
            (map + (rest lazy-cat-fib) lazy-cat-fib)))

(def __ #(take % lazy-cat-fib))
````

2. Remove `(def __ :tests-will-fail)`
3. Start a project REPL and connect (Jack-In ).
4. Load the current file so that what we've pasted is evaluated.
5. Run tests and make sure they pass.